### PR TITLE
(fix): removed redundant return type

### DIFF
--- a/client/cl_scenes.lua
+++ b/client/cl_scenes.lua
@@ -53,7 +53,6 @@ local function startScene(self)
 end
 
 ---@param payload rv_scenes | rv_scenes[]
----@return string
 exports('createScene', function(payload)
     payload = table.type(payload) == 'array' and payload or { payload }
 


### PR DESCRIPTION
This PR removes the redundant return type in the createScene export declared in ```client/cl_scenes.lua```